### PR TITLE
Skip .data sections in .text. Fix for OpenSSL asm code

### DIFF
--- a/src/BinaryContext.h
+++ b/src/BinaryContext.h
@@ -207,6 +207,10 @@ public:
   /// when a function has more than a single entry point.
   std::set<uint64_t> InterproceduralReferences;
 
+  /// Set of pointers to .data segments found in .text section
+  /// This is workaround for plain assembly segments(e.g OpenSSL crypto functions)
+  std::set<BinaryData *> DataInTextPointers;
+
   std::unique_ptr<MCContext> Ctx;
 
   std::unique_ptr<DWARFContext> DwCtx;


### PR DESCRIPTION
OpenSSL has code like this:

```
.globl	Camellia_EncryptBlock_Rounds
--
.type	Camellia_EncryptBlock_Rounds,@function
.align	16
.Lenc_rounds:
Camellia_EncryptBlock_Rounds:
pushq	%rbx
pushq	%rbp
pushq	%r13
pushq	%r14
pushq	%r15
.Lenc_prologue:
 
 
movq	%rcx,%r13
movq	%rdx,%r14
 
shll	$6,%edi
leaq	.LCamellia_SBOX(%rip),%rbp
leaq	(%r14,%rdi,1),%r15
```

Where LCamellia_SBOX is data:

```
.LCamellia_SBOX:
--
.long	0x70707000,0x70700070
.long	0x82828200,0x2c2c002c
.long	0x2c2c2c00,0xb3b300b3
.long	0xececec00,0xc0c000c0
```

This patch prevents adding this symbols to InterproceduralReferences set.
