### PR TITLE
Fix compiler warnings in BinaryContext and RegAnalysis

### DIFF
--- a/src/BinaryContext.cpp
+++ b/src/BinaryContext.cpp
@@ -872,11 +872,11 @@ void BinaryContext::printInstruction(raw_ostream &OS,
       OS << " # TAILCALL ";
     if (MIB->isInvoke(Instruction)) {
       if (const auto EHInfo = MIB->getEHInfo(Instruction)) {
-      OS << " # handler: ";
+        OS << " # handler: ";
         if (EHInfo->first)
           OS << *EHInfo->first;
-      else
-        OS << '0';
+        else
+          OS << '0';
         OS << "; action: " << EHInfo->second;
       }
       auto GnuArgsSize = MIB->getGnuArgsSize(Instruction);

--- a/src/Passes/RegAnalysis.cpp
+++ b/src/Passes/RegAnalysis.cpp
@@ -105,6 +105,7 @@ void RegAnalysis::beConservative(BitVector &Result) const {
     BC.MIB->getCalleeSavedRegs(BV);
     BV.flip();
     Result |= BV;
+    break;
   }
   case ConservativeStrategy::CLOBBERS_NONE:
     Result.reset();


### PR DESCRIPTION
This pull request fixes two compiler warnings:

- missing `break;` in a switch-case statement in RegAnalysis.cpp (-Wimplicit-fallthrough warning)
- misleading indentation in BinaryContext.cpp (-Wmisleading-indentation warning)