### PR TITLE
Fix URL in code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
 Facebook has adopted a Code of Conduct that we expect project participants to adhere to.
-Please read the [full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct)
+Please read the [full text](https://code.fb.com/codeofconduct/)
 so that you can understand what actions will and will not be tolerated.


### PR DESCRIPTION
https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct doesn't work; it gives a "The content you’re looking for is not available at this URL."

Searching on code.fb.com led me to the URL in this pull request, which I'm assuming is the correct one for Facebook's open source projects.