### PR TITLE
Handle TLS relocations on AArch64

### DIFF
--- a/src/RewriteInstance.cpp
+++ b/src/RewriteInstance.cpp
@@ -2230,8 +2230,8 @@ void RewriteInstance::readRelocations(const SectionRef &Section) {
       RType &= ~ELF::R_X86_64_converted_reloc_bit;
     }
 
-    // No special handling required for TLS relocations.
-    if (Relocation::isTLS(RType))
+    // No special handling required for TLS relocations on X86.
+    if (Relocation::isTLS(RType) && BC->isX86())
       continue;
 
     if (BC->getDynamicRelocationAt(Rel.getOffset())) {


### PR DESCRIPTION
Some of the TLS relocatios like R_AARCH64_TLSDESC_ADR_PAGE21 must be
handled by bolt and should not be skipped by the removed condition. Some
of the TLS relocations like R_AARCH64_TLS_TPREL64 could really be skipped
here, but AFAIU this condition was added as part of BOLT its self optimization, so
to prevent future problems here my suggestion is not to add another condition
like "isTLS(RType) && isTLSRelocatable(RType)", but just remove it since
absense of this condition should not broke any other TLS relocation.
Vladislav Khmelevsky,
Advanced Software Technology Lab, Huawei