### PR TITLE
readDynamicRelocations: Skip NONE relocations

### DIFF
--- a/src/Relocation.cpp
+++ b/src/Relocation.cpp
@@ -350,6 +350,12 @@ bool Relocation::isGOT(uint64_t Type) {
   return isGOTX86(Type);
 }
 
+bool Relocation::isNone(uint64_t Type) {
+  if (Arch == Triple::aarch64)
+    return Type == ELF::R_AARCH64_NONE;
+  return Type == ELF::R_X86_64_NONE;
+}
+
 bool Relocation::isTLS(uint64_t Type) {
   if (Arch == Triple::aarch64)
     return isTLSAArch64(Type);

--- a/src/Relocation.h
+++ b/src/Relocation.h
@@ -70,6 +70,9 @@ struct Relocation {
   /// Return true if relocation type implies the creation of a GOT entry
   static bool isGOT(uint64_t Type);
 
+  /// Return true if relocation type is NONE
+  static bool isNone(uint64_t Type);
+
   /// Return true if relocation type is for thread local storage.
   static bool isTLS(uint64_t Type);
 

--- a/src/RewriteInstance.cpp
+++ b/src/RewriteInstance.cpp
@@ -2159,13 +2159,16 @@ void RewriteInstance::readDynamicRelocations(const SectionRef &Section) {
                << SectionName << ":\n");
 
   for (const auto &Rel : Section.relocations()) {
-    auto SymbolIter = Rel.getSymbol();
+    auto RType = Rel.getType();
+    if (Relocation::isNone(RType))
+      continue;
 
     StringRef SymbolName = "<none>";
     MCSymbol *Symbol = nullptr;
     uint64_t SymbolAddress = 0;
     const uint64_t Addend = getRelocationAddend(InputFile, Rel);
 
+    auto SymbolIter = Rel.getSymbol();
     if (SymbolIter != InputFile->symbol_end()) {
       SymbolName = cantFail(SymbolIter->getName());
       auto *BD = BC->getBinaryDataByName(SymbolName);


### PR DESCRIPTION
NONE relocations should not be processed during dynamic relocations read process
Vladislav Khmelevsky,
Advanced Software Technology Lab, Huawei