### PR TITLE
Fix compilation error

### DIFF
--- a/llvm.patch
+++ b/llvm.patch
@@ -3524,6 +3524,22 @@ index c58254ae38c..ab9241e5530 100644
        }
        Instr.setFlags(Flags);
      }
+@@ -265,13 +267,13 @@ MCDisassembler::DecodeStatus X86GenericDisassembler::getInstruction(
+ /// @param reg        - The Reg to append.
+ static void translateRegister(MCInst &mcInst, Reg reg) {
+ #define ENTRY(x) X86::x,
+-  uint8_t llvmRegnums[] = {
++  MCPhysReg llvmRegnums[] = {
+     ALL_REGS
+     0
+   };
+ #undef ENTRY
+ 
+-  uint8_t llvmRegnum = llvmRegnums[reg];
++  MCPhysReg llvmRegnum = llvmRegnums[reg];
+   mcInst.addOperand(MCOperand::createReg(llvmRegnum));
+ }
+ 
 diff --git a/lib/Target/X86/Disassembler/X86DisassemblerDecoder.cpp b/lib/Target/X86/Disassembler/X86DisassemblerDecoder.cpp
 index 6a10278dc7f..626b1439871 100644
 --- a/lib/Target/X86/Disassembler/X86DisassemblerDecoder.cpp


### PR DESCRIPTION
This BOLT commit causes a compilation error for me:
https://github.com/facebookincubator/BOLT/commit/002d2367f9996f8faa9ef512af5491c45c12a44a

```
llvm/lib/Target/X86/Disassembler/X86Disassembler.cpp:271:5: error: constant expression evaluates to 256 which cannot be narrowed to type 'uint8_t' (aka 'unsigned char') [-Wc++11-narrowing]
    ALL_REGS
    ^~~~~~~~
llvm/lib/Target/X86/Disassembler/X86DisassemblerDecoder.h:389:3: note: expanded from macro 'ALL_REGS'
  REGS_16BIT          \
  ^~~~~~~~~~
llvm/lib/Target/X86/Disassembler/X86DisassemblerDecoder.h:132:3: note: expanded from macro 'REGS_16BIT'
  ENTRY(R15W)
  ^~~~~~~~~~~
llvm/lib/Target/X86/Disassembler/X86Disassembler.cpp:269:18: note: expanded from macro 'ENTRY'
                 ^~~~~~
llvm/lib/Target/X86/Disassembler/X86Disassembler.cpp:271:5: note: insert an explicit cast to silence this issue
    ALL_REGS
    ^~~~~~~~
llvm/lib/Target/X86/Disassembler/X86DisassemblerDecoder.h:389:3: note: expanded from macro 'ALL_REGS'
  REGS_16BIT          \
  ^~~~~~~~~~
llvm/lib/Target/X86/Disassembler/X86DisassemblerDecoder.h:132:3: note: expanded from macro 'REGS_16BIT'
  ENTRY(R15W)
  ^~~~~~~~~~~
llvm/lib/Target/X86/Disassembler/X86Disassembler.cpp:269:18: note: expanded from macro 'ENTRY'
                 ^~~~~~
```

It looks like the issue is that the original LLVM commit updated llvmRegnums to be a MCPhysReg (uint16_t), but the BOLT cherry-pick of this commit keeps it as a uint8_t.