### PR TITLE
Instrumentation: Introduce -no-counters-clear and -wait-forks options  

### DIFF
--- a/runtime/common.h
+++ b/runtime/common.h
@@ -333,6 +333,36 @@ uint64_t __getppid() {
   return ret;
 }
 
+int __setpgid(uint64_t pid, uint64_t pgid) {
+  int ret;
+  __asm__ __volatile__("movq $109, %%rax\n"
+                       "syscall\n"
+                       : "=a"(ret)
+                       : "D"(pid), "S"(pgid)
+                       : "cc", "rcx", "r11", "memory");
+  return ret;
+}
+
+uint64_t __getpgid(uint64_t pid) {
+  uint64_t ret;
+  __asm__ __volatile__("movq $121, %%rax\n"
+                       "syscall\n"
+                       : "=a"(ret)
+                       : "D"(pid)
+                       : "cc", "rcx", "r11", "memory");
+  return ret;
+}
+
+int __kill(uint64_t pid, int sig) {
+  int ret;
+  __asm__ __volatile__("movq $62, %%rax\n"
+                       "syscall\n"
+                       : "=a"(ret)
+                       : "D"(pid), "S"(sig)
+                       : "cc", "rcx", "r11", "memory");
+  return ret;
+}
+
 #endif
 
 void reportError(const char *Msg, uint64_t Size) {

--- a/runtime/instr.cpp
+++ b/runtime/instr.cpp
@@ -90,6 +90,8 @@ extern uint32_t __bolt_instr_num_funcs;
 extern uint32_t __bolt_instr_sleep_time;
 // Do not clear counters across dumps, rewrite file with the updated values
 extern bool __bolt_instr_no_counters_clear;
+// Wait until all forks of instrumented process will finish
+extern bool __bolt_instr_wait_forks;
 // Filename to dump data to
 extern char __bolt_instr_filename[];
 // If true, append current PID to the fdata filename when creating it so
@@ -1408,26 +1410,43 @@ extern "C" void __bolt_instr_data_dump() {
 void watchProcess() {
   timespec ts, rem;
   uint64_t Ellapsed = 0ull;
+  uint64_t ppid;
+  if (__bolt_instr_wait_forks) {
+    // Store parent pgid
+    ppid = -__getpgid(0);
+    // And leave parent process group
+    __setpgid(0, 0);
+  } else {
+    // Store parent pid
+    ppid = __getppid();
+    if (ppid == 1) {
+      // Parent already dead
+      goto out;
+    }
+  }
+
   ts.tv_sec = 1;
   ts.tv_nsec = 0;
   while (1) {
     __nanosleep(&ts, &rem);
-    // This means our parent process died, so no need for us to keep dumping.
-    // Notice that make and some systems will wait until all child processes
-    // of a command finishes before proceeding, so it is important to exit as
-    // early as possible once our parent dies.
-    if (__getppid() == 1) {
+    // This means our parent process or all its forks are dead,
+    // so no need for us to keep dumping.
+    if (__kill(ppid, 0) < 0) {
       if (__bolt_instr_no_counters_clear)
         __bolt_instr_data_dump();
       break;
     }
+
     if (++Ellapsed < __bolt_instr_sleep_time)
       continue;
+
     Ellapsed = 0;
     __bolt_instr_data_dump();
     if (__bolt_instr_no_counters_clear == false)
       __bolt_instr_clear_counters();
   }
+
+out:;
   DEBUG(report("My parent process is dead, bye!\n"));
   __exit(0);
 }
@@ -1462,6 +1481,10 @@ extern "C" void __bolt_instr_setup() {
         new (GlobalAlloc, 0) IndirectCallHashTable[__bolt_instr_num_ind_calls];
 
   if (__bolt_instr_sleep_time != 0) {
+    // Separate instrumented process to the own process group
+    if (__bolt_instr_wait_forks)
+      __setpgid(0, 0);
+
     if (auto PID = __fork())
       return;
     watchProcess();

--- a/src/Passes/Instrumentation.cpp
+++ b/src/Passes/Instrumentation.cpp
@@ -49,6 +49,14 @@ cl::opt<uint32_t> InstrumentationSleepTime(
              "program and the profile is not being dumped at the end."),
     cl::init(0), cl::Optional, cl::cat(BoltInstrCategory));
 
+cl::opt<bool> InstrumentationNoCountersClear(
+    "instrumentation-no-counters-clear",
+    cl::desc("Don't clear counters across dumps "
+             "(use with instrumentation-sleep-time option)"),
+    cl::init(false),
+    cl::Optional,
+    cl::cat(BoltInstrCategory));
+
 cl::opt<bool>
     InstrumentHotOnly("instrument-hot-only",
                       cl::desc("only insert instrumentation on hot functions "

--- a/src/Passes/Instrumentation.cpp
+++ b/src/Passes/Instrumentation.cpp
@@ -53,9 +53,13 @@ cl::opt<bool> InstrumentationNoCountersClear(
     "instrumentation-no-counters-clear",
     cl::desc("Don't clear counters across dumps "
              "(use with instrumentation-sleep-time option)"),
-    cl::init(false),
-    cl::Optional,
-    cl::cat(BoltInstrCategory));
+    cl::init(false), cl::Optional, cl::cat(BoltInstrCategory));
+
+cl::opt<bool> InstrumentationWaitForks(
+    "instrumentation-wait-forks",
+    cl::desc("Wait until all forks of instrumented process will finish "
+             "(use with instrumentation-sleep-time option)"),
+    cl::init(false), cl::Optional, cl::cat(BoltInstrCategory));
 
 cl::opt<bool>
     InstrumentHotOnly("instrument-hot-only",

--- a/src/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
+++ b/src/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
@@ -94,33 +94,43 @@ void InstrumentationRuntimeLibrary::emitBinary(BinaryContext &BC,
                                  "__BOLT", "__counters", MachO::S_REGULAR,
                                  SectionKind::getData()));
 
+  Section->setAlignment(BC.RegularPageSize);
+  Streamer.SwitchSection(Section);
+
+  auto EmitLabel = [&](MCSymbol *Symbol, bool IsGlobal = true) {
+    Streamer.EmitLabel(Symbol);
+    if (IsGlobal)
+      Streamer.EmitSymbolAttribute(Symbol, MCSymbolAttr::MCSA_Global);
+  };
+
+  auto EmitLabelByName = [&](const char *Name, bool IsGlobal = true) {
+    MCSymbol *Symbol = BC.Ctx->getOrCreateSymbol(Name);
+    EmitLabel(Symbol, IsGlobal);
+  };
+
+  auto EmitValue = [&](MCSymbol *Symbol, const MCExpr *Value) {
+    EmitLabel(Symbol);
+    Streamer.EmitValue(Value, /*Size*/ 8);
+  };
+
+  auto EmitIntValue = [&](const char *Name, uint64_t Value, unsigned Size = 4) {
+    EmitLabelByName(Name);
+    Streamer.EmitIntValue(Value, Size);
+  };
+
+  auto EmitString = [&](const char *Name, std::string String) {
+    EmitLabelByName(Name);
+    Streamer.EmitBytes(String);
+    Streamer.emitFill(1, 0);
+  };
+
   // All of the following symbols will be exported as globals to be used by the
   // instrumentation runtime library to dump the instrumentation data to disk.
   // Label marking start of the memory region containing instrumentation
   // counters, total vector size is Counters.size() 8-byte counters
-  MCSymbol *Locs = BC.Ctx->getOrCreateSymbol("__bolt_instr_locations");
-  MCSymbol *NumLocs = BC.Ctx->getOrCreateSymbol("__bolt_num_counters");
-  MCSymbol *NumIndCalls =
-      BC.Ctx->getOrCreateSymbol("__bolt_instr_num_ind_calls");
-  MCSymbol *NumIndCallTargets =
-      BC.Ctx->getOrCreateSymbol("__bolt_instr_num_ind_targets");
-  MCSymbol *NumFuncs = BC.Ctx->getOrCreateSymbol("__bolt_instr_num_funcs");
-  /// File name where profile is going to written to after target binary
-  /// finishes a run
-  MCSymbol *FilenameSym = BC.Ctx->getOrCreateSymbol("__bolt_instr_filename");
-  MCSymbol *UsePIDSym = BC.Ctx->getOrCreateSymbol("__bolt_instr_use_pid");
-  MCSymbol *InitPtr = BC.Ctx->getOrCreateSymbol("__bolt_instr_init_ptr");
-  MCSymbol *FiniPtr = BC.Ctx->getOrCreateSymbol("__bolt_instr_fini_ptr");
-  MCSymbol *SleepSym = BC.Ctx->getOrCreateSymbol("__bolt_instr_sleep_time");
-  MCSymbol *ClearSym = BC.Ctx->getOrCreateSymbol("__bolt_instr_no_counters_clear");
-  MCSymbol *WaitForks = BC.Ctx->getOrCreateSymbol("__bolt_instr_wait_forks");
-
-  Section->setAlignment(BC.RegularPageSize);
-  Streamer.SwitchSection(Section);
-  Streamer.EmitLabel(Locs);
-  Streamer.EmitSymbolAttribute(Locs, MCSymbolAttr::MCSA_Global);
+  EmitLabelByName("__bolt_instr_locations");
   for (const auto &Label : Summary->Counters) {
-    Streamer.EmitLabel(Label);
+    EmitLabel(Label, /*IsGlobal*/ false);
     Streamer.emitFill(8, 0);
   }
   const uint64_t Padding =
@@ -128,79 +138,40 @@ void InstrumentationRuntimeLibrary::emitBinary(BinaryContext &BC,
       8 * Summary->Counters.size();
   if (Padding)
     Streamer.emitFill(Padding, 0);
-  Streamer.EmitLabel(SleepSym);
-  Streamer.EmitSymbolAttribute(SleepSym, MCSymbolAttr::MCSA_Global);
-  Streamer.EmitIntValue(opts::InstrumentationSleepTime, /*Size=*/4);
 
-  Streamer.EmitLabel(ClearSym);
-  Streamer.EmitSymbolAttribute(ClearSym, MCSymbolAttr::MCSA_Global);
-  Streamer.EmitIntValue(opts::InstrumentationNoCountersClear ? 1 : 0, /*Size=*/1);
-
-  Streamer.EmitLabel(WaitForks);
-  Streamer.EmitSymbolAttribute(WaitForks, MCSymbolAttr::MCSA_Global);
-  Streamer.EmitIntValue(opts::InstrumentationWaitForks ? 1 : 0, /*Size=*/1);
-
-  Streamer.EmitLabel(NumLocs);
-  Streamer.EmitSymbolAttribute(NumLocs, MCSymbolAttr::MCSA_Global);
-  Streamer.EmitIntValue(Summary->Counters.size(), /*Size=*/4);
-
-  Streamer.EmitLabel(Summary->IndCallHandlerFunc);
-  Streamer.EmitSymbolAttribute(Summary->IndCallHandlerFunc,
-                               MCSymbolAttr::MCSA_Global);
-  Streamer.EmitValue(
+  EmitIntValue("__bolt_instr_sleep_time", opts::InstrumentationSleepTime);
+  EmitIntValue("__bolt_instr_no_counters_clear",
+               !!opts::InstrumentationNoCountersClear, 1);
+  EmitIntValue("__bolt_instr_wait_forks", !!opts::InstrumentationWaitForks, 1);
+  EmitIntValue("__bolt_num_counters", Summary->Counters.size());
+  EmitValue(Summary->IndCallHandlerFunc,
+            MCSymbolRefExpr::create(
+                Summary->InitialIndCallHandlerFunction->getSymbol(), *BC.Ctx));
+  EmitValue(
+      Summary->IndTailCallHandlerFunc,
       MCSymbolRefExpr::create(
-          Summary->InitialIndCallHandlerFunction->getSymbol(), *BC.Ctx),
-      /*Size=*/8);
-
-  Streamer.EmitLabel(Summary->IndTailCallHandlerFunc);
-  Streamer.EmitSymbolAttribute(Summary->IndTailCallHandlerFunc,
-                               MCSymbolAttr::MCSA_Global);
-  Streamer.EmitValue(
-      MCSymbolRefExpr::create(
-          Summary->InitialIndTailCallHandlerFunction->getSymbol(), *BC.Ctx),
-      /*Size=*/8);
-
-  Streamer.EmitLabel(NumIndCalls);
-  Streamer.EmitSymbolAttribute(NumIndCalls, MCSymbolAttr::MCSA_Global);
-  Streamer.EmitIntValue(Summary->IndCallDescriptions.size(), /*Size=*/4);
-
-  Streamer.EmitLabel(NumIndCallTargets);
-  Streamer.EmitSymbolAttribute(NumIndCallTargets, MCSymbolAttr::MCSA_Global);
-  Streamer.EmitIntValue(Summary->IndCallTargetDescriptions.size(), /*Size=*/4);
-
-  Streamer.EmitLabel(NumFuncs);
-  Streamer.EmitSymbolAttribute(NumFuncs, MCSymbolAttr::MCSA_Global);
-  Streamer.EmitIntValue(Summary->FunctionDescriptions.size(), /*Size=*/4);
-
-  Streamer.EmitLabel(FilenameSym);
-  Streamer.EmitBytes(opts::InstrumentationFilename);
-  Streamer.emitFill(1, 0);
-
-  Streamer.EmitLabel(UsePIDSym);
-  Streamer.EmitIntValue(opts::InstrumentationFileAppendPID ? 1 : 0, /*Size=*/1);
-
-  Streamer.EmitLabel(InitPtr);
-  Streamer.EmitSymbolAttribute(InitPtr, MCSymbolAttr::MCSA_Global);
-  Streamer.EmitValue(
-      MCSymbolRefExpr::create(StartFunction->getSymbol(), *BC.Ctx), /*Size=*/8);
-
+          Summary->InitialIndTailCallHandlerFunction->getSymbol(), *BC.Ctx));
+  EmitIntValue("__bolt_instr_num_ind_calls",
+               Summary->IndCallDescriptions.size());
+  EmitIntValue("__bolt_instr_num_ind_targets",
+               Summary->IndCallTargetDescriptions.size());
+  EmitIntValue("__bolt_instr_num_funcs", Summary->FunctionDescriptions.size());
+  EmitString("__bolt_instr_filename", opts::InstrumentationFilename);
+  EmitIntValue("__bolt_instr_use_pid", !!opts::InstrumentationFileAppendPID, 1);
+  EmitValue(BC.Ctx->getOrCreateSymbol("__bolt_instr_init_ptr"),
+            MCSymbolRefExpr::create(StartFunction->getSymbol(), *BC.Ctx));
   if (FiniFunction) {
-    Streamer.EmitLabel(FiniPtr);
-    Streamer.EmitSymbolAttribute(FiniPtr, MCSymbolAttr::MCSA_Global);
-    Streamer.EmitValue(
-      MCSymbolRefExpr::create(FiniFunction->getSymbol(), *BC.Ctx), /*Size=*/8);
+    EmitValue(BC.Ctx->getOrCreateSymbol("__bolt_instr_fini_ptr"),
+              MCSymbolRefExpr::create(FiniFunction->getSymbol(), *BC.Ctx));
   }
 
   if (BC.isMachO()) {
     MCSection *TablesSection = BC.Ctx->getMachOSection(
                                  "__BOLT", "__tables", MachO::S_REGULAR,
                                  SectionKind::getData());
-    MCSymbol *Tables = BC.Ctx->getOrCreateSymbol("__bolt_instr_tables");
     TablesSection->setAlignment(BC.RegularPageSize);
     Streamer.SwitchSection(TablesSection);
-    Streamer.EmitLabel(Tables);
-    Streamer.EmitSymbolAttribute(Tables, MCSymbolAttr::MCSA_Global);
-    Streamer.EmitBytes(buildTables(BC));
+    EmitString("__bolt_instr_tables", buildTables(BC));
   }
 }
 

--- a/src/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
+++ b/src/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
@@ -23,6 +23,7 @@ extern cl::OptionCategory BoltOptCategory;
 extern cl::opt<bool> InstrumentationFileAppendPID;
 extern cl::opt<std::string> InstrumentationFilename;
 extern cl::opt<uint32_t> InstrumentationSleepTime;
+extern cl::opt<bool> InstrumentationNoCountersClear;
 
 cl::opt<bool>
     Instrument("instrument",
@@ -110,6 +111,7 @@ void InstrumentationRuntimeLibrary::emitBinary(BinaryContext &BC,
   MCSymbol *InitPtr = BC.Ctx->getOrCreateSymbol("__bolt_instr_init_ptr");
   MCSymbol *FiniPtr = BC.Ctx->getOrCreateSymbol("__bolt_instr_fini_ptr");
   MCSymbol *SleepSym = BC.Ctx->getOrCreateSymbol("__bolt_instr_sleep_time");
+  MCSymbol *ClearSym = BC.Ctx->getOrCreateSymbol("__bolt_instr_no_counters_clear");
 
   Section->setAlignment(BC.RegularPageSize);
   Streamer.SwitchSection(Section);
@@ -127,6 +129,9 @@ void InstrumentationRuntimeLibrary::emitBinary(BinaryContext &BC,
   Streamer.EmitLabel(SleepSym);
   Streamer.EmitSymbolAttribute(SleepSym, MCSymbolAttr::MCSA_Global);
   Streamer.EmitIntValue(opts::InstrumentationSleepTime, /*Size=*/4);
+  Streamer.EmitLabel(ClearSym);
+  Streamer.EmitSymbolAttribute(ClearSym, MCSymbolAttr::MCSA_Global);
+  Streamer.EmitIntValue(opts::InstrumentationNoCountersClear ? 1 : 0, /*Size=*/1);
   Streamer.EmitLabel(NumLocs);
   Streamer.EmitSymbolAttribute(NumLocs, MCSymbolAttr::MCSA_Global);
   Streamer.EmitIntValue(Summary->Counters.size(), /*Size=*/4);


### PR DESCRIPTION
Hello! This PR introduces 2 new instrumentation options:
1. instrumentation-no-counters-clear: Discussed at #121 
2. instrumentation-wait-forks: Since the instrumentation counters are mapped as MAP_SHARED it will be nice to add ability to wait until all forks of the parent process will die using tracking of process group.
The last patch is just emitBinary code refactor. 
Vladislav Khmelevsky,
Advanced Software Technology Lab, Huawei 