### PR TITLE
Fix constant islands handling

### DIFF
--- a/bolt/src/BinaryContext.cpp
+++ b/bolt/src/BinaryContext.cpp
@@ -441,12 +441,7 @@ BinaryContext::handleAddressRef(uint64_t Address, BinaryFunction &BF,
     if (IslandIter != AddressToConstantIslandMap.end()) {
       if (MCSymbol *IslandSym =
               IslandIter->second->getOrCreateProxyIslandAccess(Address, BF)) {
-        /// Make this function depend on IslandIter->second because we have
-        /// a reference to its constant island. When emitting this function,
-        /// we will also emit IslandIter->second's constants. This only
-        /// happens in custom AArch64 assembly code.
-        BF.Islands->Dependency.insert(IslandIter->second);
-        BF.Islands->ProxySymbols[IslandSym] = IslandIter->second;
+        BF.createIslandDependency(IslandSym, IslandIter->second);
         return std::make_pair(IslandSym, Addend);
       }
     }

--- a/bolt/src/BinaryEmitter.cpp
+++ b/bolt/src/BinaryEmitter.cpp
@@ -496,7 +496,7 @@ void BinaryEmitter::emitFunctionBody(BinaryFunction &BF, bool EmitColdPart,
 
 void BinaryEmitter::emitConstantIslands(BinaryFunction &BF, bool EmitColdPart,
                                         BinaryFunction *OnBehalfOf) {
-  if (!BF.hasConstantIsland())
+  if (!BF.hasIslandsInfo())
     return;
 
   BinaryFunction::IslandInfo &Islands = BF.getIslandInfo();

--- a/bolt/src/BinaryFunction.h
+++ b/bolt/src/BinaryFunction.h
@@ -2177,6 +2177,17 @@ public:
     return Proxy;
   }
 
+  /// Make this function depend on \p BF because we have a reference to its
+  /// constant island. When emitting this function,  we will also emit
+  //  \p BF's constants. This only happens in custom AArch64 assembly code.
+  void createIslandDependency(MCSymbol *Island, BinaryFunction *BF) {
+    if (!Islands)
+      Islands = std::make_unique<IslandInfo>();
+
+    Islands->Dependency.insert(BF);
+    Islands->ProxySymbols[Island] = BF;
+  }
+
   /// Detects whether \p Address is inside a data region in this function
   /// (constant islands).
   bool isInConstantIsland(uint64_t Address) const {
@@ -2235,6 +2246,10 @@ public:
         Size += ExternalFunc->estimateConstantIslandSize(this);
     }
     return Size;
+  }
+
+  bool hasIslandsInfo() const {
+    return !!Islands;
   }
 
   bool hasConstantIsland() const {

--- a/bolt/src/Passes/ADRRelaxationPass.cpp
+++ b/bolt/src/Passes/ADRRelaxationPass.cpp
@@ -37,12 +37,11 @@ void ADRRelaxationPass::runOnFunction(BinaryContext &BC, BinaryFunction &BF) {
       if (!Symbol)
         continue;
 
-      if (!BF.hasConstantIsland())
-        continue;
-
-      BinaryFunction::IslandInfo &Islands = BF.getIslandInfo();
-      if (Islands.Symbols.count(Symbol) || Islands.ProxySymbols.count(Symbol))
-        continue;
+      if (BF.hasIslandsInfo()) {
+        BinaryFunction::IslandInfo &Islands = BF.getIslandInfo();
+        if (Islands.Symbols.count(Symbol) || Islands.ProxySymbols.count(Symbol))
+          continue;
+      }
 
       BinaryFunction *TargetBF = BC.getFunctionForSymbol(Symbol);
       if (TargetBF && TargetBF == &BF)


### PR DESCRIPTION
After the "Allocate memory for constant islands on-demand" patch there
are couple of problems found in constant islands handling:
1. When creating constant island dependency we need to check that we
already allocated IslandInfo for BF.
2. In ADRRelaxationPass we need to set constant island check under new
hasIslandsInfo condition.
3. In binaryemitter we need to replace hasConstantIsland with
hasIslandsInfo check since originally the BF might not have constant
island, but might have access to other's BF CI.