### PR TITLE
Disable instrumentation and hugify build for aarch64

### DIFF
--- a/bolt/runtime/hugify.cpp
+++ b/bolt/runtime/hugify.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if defined (__x86_64__)
 #if !defined(__APPLE__)
 
 #include "common.h"
@@ -124,4 +125,5 @@ extern "C" __attribute((naked)) void __bolt_hugify_self() {
                        :::);
 }
 
+#endif
 #endif

--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -40,6 +40,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if defined (__x86_64__)
 #include "common.h"
 
 // Enables a very verbose logging to stderr useful when debugging
@@ -1668,4 +1669,5 @@ void _bolt_instr_fini() {
   __bolt_instr_data_dump();
 }
 
+#endif
 #endif


### PR DESCRIPTION
This patch temporarily disables instrumentation and higufy build not for
x86 platforms to be able to build llvm-bolt tool on aarch64.