### PR TITLE
Disable InlineMemcpy with NoInline

### DIFF
--- a/bolt/src/Passes/BinaryPasses.cpp
+++ b/bolt/src/Passes/BinaryPasses.cpp
@@ -52,6 +52,8 @@ const char* dynoStatsOptDesc(const bolt::DynoStats::Category C) {
 
 namespace opts {
 
+extern cl::opt<bool> NoInline;
+
 extern cl::OptionCategory BoltCategory;
 extern cl::OptionCategory BoltOptCategory;
 
@@ -1585,7 +1587,7 @@ void StripRepRet::runOnFunctions(BinaryContext &BC) {
 }
 
 void InlineMemcpy::runOnFunctions(BinaryContext &BC) {
-  if (!BC.isX86())
+  if (!BC.isX86() || opts::NoInline)
     return;
 
   uint64_t NumInlined = 0;

--- a/bolt/src/Passes/Inliner.cpp
+++ b/bolt/src/Passes/Inliner.cpp
@@ -105,12 +105,10 @@ InlineSmallFunctionsBytes("inline-small-functions-bytes",
   cl::Hidden,
   cl::cat(BoltOptCategory));
 
-static cl::opt<bool>
-NoInline("no-inline",
-  cl::desc("disable all inlining (overrides other inlining options)"),
-  cl::init(false),
-  cl::ZeroOrMore,
-  cl::cat(BoltOptCategory));
+cl::opt<bool> NoInline(
+    "no-inline",
+    cl::desc("disable all inlining (overrides other inlining options)"),
+    cl::init(false), cl::ZeroOrMore, cl::cat(BoltOptCategory));
 
 /// This function returns true if any of inlining options are specified and the
 /// inlining pass should be executed. Whenever a new inlining option is added,


### PR DESCRIPTION
Sometimes we want completely disable inlining optimizations, disable
memcpy when NoInline option is passed

Vladislav Khmelevsky,
Advanced Software Technology Lab, Huawei