### PR TITLE
instr: change assert to allow FD 0 return by __open()

### DIFF
--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -626,7 +626,7 @@ static char *getBinaryPath() {
   uint64_t FDdir = __open(DirPath,
                           /*flags=*/0 /*O_RDONLY*/,
                           /*mode=*/0666);
-  assert(static_cast<int64_t>(FDdir) > 0,
+  assert(static_cast<int64_t>(FDdir) >= 0,
          "failed to open /proc/self/map_files");
 
   while (long Nread = __getdents(FDdir, (struct dirent *)Buf, BufSize)) {
@@ -662,7 +662,7 @@ ProfileWriterContext readDescriptions() {
   uint64_t FD = __open(BinPath,
                        /*flags=*/0 /*O_RDONLY*/,
                        /*mode=*/0666);
-  assert(static_cast<int64_t>(FD) > 0, "failed to open binary path");
+  assert(static_cast<int64_t>(FD) >= 0, "failed to open binary path");
 
   Result.FileDesc = FD;
 


### PR DESCRIPTION
In some cases `__open()` is returning 0 for me.
The open syscall will return a negative number (-1) on error so 0 should be valid.

This happens when one compiles a bolt instrumented executable of pyston (python implementation) and afterwards pip installs a package which needs to be compiled and sets `CFLAGS=-pipe`.
I could not reduce it down to a small testcase but I guess it one can trigger when manually closing std{in, out, err}.
Every thing seems to work normally when disabling the assert for 0 in `getBinaryPath()` - I decided to also modify the second case in `readDescriptions()` even though I did not run into that one yet.