### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/issue-subscriber.yml
+++ b/.github/workflows/issue-subscriber.yml
@@ -5,6 +5,7 @@ on:
     types:
       - labeled
 
+permissions: {}
 jobs:
   auto-subscribe:
     runs-on: ubuntu-latest

--- a/.github/workflows/llvm-bugs.yml
+++ b/.github/workflows/llvm-bugs.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
 
+permissions: {}
 jobs:
   auto-subscribe:
     runs-on: ubuntu-latest

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -3,8 +3,11 @@ on:
   issues:
     types: ['opened']
 
+permissions: {}
 jobs:
   automate-issues-labels:
+    permissions:
+      issues: write # to label issues (andymckay/labeler)
     runs-on: ubuntu-latest
     if: github.repository == 'llvm/llvm-project'
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.